### PR TITLE
feat: show schema versions and change extern detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ Dies eignet sich um nachträglich Zahlen zu einem bestimmten Datum zu ermitteln.
 
 Der optionale Parameter `--include-extern` schließt Meldungen mit externer Diagnosestellung ein.
 Diese sind normalerweise nicht enthalten.
+Die Entscheidung, ob eine Meldung intern oder extern gemeldet wird, wird anhand der `Melder_ID` getroffen.
+Enthält diese die Zeichenkette `9999` wird von einer externen Meldung ausgegangen.
 
 Der optionale Parameter `--include-histo-zyto` schließt Meldungen mit Meldeanlass `histologhie_zytologie` ein.
 Diese sind normalerweise ebenfalls nicht enthalten.
+
+Mit dem optionalen Parameter `--schema-versions` werden die Angaben zudem noch oBDS-Schema-Version getrennt ausgegeben.
 
 ## Export aus der Onkostar-Datenbank
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,8 @@ pub enum SubCommand {
             help = "Meldungen mit Meldeanlass 'histologie_zytologie' einschließen"
         )]
         include_histo_zyto: bool,
+        #[arg(long, help = "Meldungen mit oBDS-Schema-version anzeigen")]
+        schema_versions: bool,
     },
     #[command(
         about = "Erstellt eine (reduzierte) CSV-Datei zum direkten Vergleich mit der OPAL-CSV-Datei"

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 pub struct Icd10GroupSize {
     pub name: String,
+    pub schema_version: Option<String>,
     pub size: usize,
 }
 
@@ -68,6 +69,7 @@ impl Check {
             .map(|(icd10, group)| (icd10, group.collect::<Vec<_>>()))
             .map(|record| Icd10GroupSize {
                 name: record.0,
+                schema_version: None,
                 size: record.1.len(),
             })
             .collect::<Vec<_>>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,26 +67,34 @@ fn print_items(items: &[Icd10GroupSize]) {
             .to_string(),
     );
     items.iter().for_each(|item| {
-        let _ = term.write_line(&format!("{:<20}={:>6}", item.name, item.size));
+        let _ = term.write_line(&format!(
+            "{:<20} {:<6} ={:>6}",
+            item.name,
+            item.schema_version.as_ref().unwrap_or(&String::new()),
+            item.size
+        ));
     });
     let sum: usize = items
         .iter()
         .filter(|item| item.name != "Other")
         .map(|item| item.size)
         .sum();
-    let _ = term.write_line(&style("─".repeat(27)).dim().to_string());
+    let _ = term.write_line(&style("─".repeat(35)).dim().to_string());
     let _ = term.write_line(
-        &style(format!("{:<20}={:>6}", "Summe (C**.*/D**.*)", sum))
-            .dim()
-            .to_string(),
+        &style(format!(
+            "{:<20} {:<6} ={:>6}",
+            "Summe (C**.*/D**.*)", "", sum
+        ))
+        .dim()
+        .to_string(),
     );
     let sum: usize = items.iter().map(|item| item.size).sum();
     let _ = term.write_line(
-        &style(format!("{:<20}={:>6}", "Gesamtsumme", sum))
+        &style(format!("{:<20} {:<6} ={:>6}", "Gesamtsumme", "", sum))
             .dim()
             .to_string(),
     );
-    let _ = term.write_line(&style("─".repeat(27)).dim().to_string());
+    let _ = term.write_line(&style("─".repeat(35)).dim().to_string());
 }
 
 fn print_extern_notice(include_extern: bool) {
@@ -123,6 +131,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             ignore_exports_since,
             include_extern,
             include_histo_zyto,
+            schema_versions,
         } => {
             let password = request_password_if_none(password);
             let year = sanitize_year(year);
@@ -141,6 +150,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     &ignore_exports_since.unwrap_or("9999-12-31".into()),
                     include_extern,
                     include_histo_zyto,
+                    schema_versions,
                 )
                 .map_err(|_e| "Fehler bei Zugriff auf die Datenbank")?;
 

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -20,6 +20,8 @@
 
 pub const SQL_QUERY: &str = include_str!("query.sql");
 
+pub const SQL_QUERY_WITH_SCHEMA_VERSION: &str = include_str!("query_with_schema_version.sql");
+
 pub const EXPORT_QUERY: &str = include_str!("export.sql");
 
 pub const EXPORTED_TO_LKR: &str = include_str!("exported-to-lkr.sql");

--- a/src/resources/query_with_schema_version.sql
+++ b/src/resources/query_with_schema_version.sql
@@ -107,7 +107,7 @@ SELECT CASE
 
            ELSE 'Other'
            END AS ICD10_GROUP,
-       '' AS schema_version,
+       schema_version,
        COUNT(*) as COUNT
 FROM (
     SELECT DISTINCT
@@ -137,4 +137,4 @@ LEFT OUTER JOIN (
 ) o2
 ON (o1.cond_id = o2.cond_id AND o1.versionsnummer < max_version)
 WHERE diagnosejahr = :year AND o2.cond_id IS NULL
-GROUP BY ICD10_GROUP;
+GROUP BY ICD10_GROUP, schema_version;


### PR DESCRIPTION
This adds a new optional argument to split conditions by used schema versions in addition to ICD10 group.

Since a JOIN on table `lkr_meldung` might use newer, not yet exported information the detection of external items will be done by using `Melder_ID`.